### PR TITLE
make platform an ID, rather than just the track number

### DIFF
--- a/lib/trip_updates.ex
+++ b/lib/trip_updates.ex
@@ -66,7 +66,7 @@ defmodule TripUpdates do
       %{stop_id: bs.stop_id},
       stop_sequence_map(bs.stop_sequence),
       boarding_status_map(bs.status),
-      platform_id_map(bs.track),
+      platform_id_map(bs.stop_id, bs.track),
       departure_map(bs.predicted_time)
     ], &Map.merge/2)
   end
@@ -104,12 +104,14 @@ defmodule TripUpdates do
     }
   end
 
-  def platform_id_map("") do
+  def platform_id_map(_, "") do
     %{}
   end
-  def platform_id_map(track) do
+  def platform_id_map(stop_id, track) do
+    platform_id = "#{stop_id}-#{String.pad_leading(track, 2, ["0"])}"
     %{
-      platform_id: track
+      track: track,
+      platform_id: platform_id
     }
   end
 

--- a/test/trip_updates_test.exs
+++ b/test/trip_updates_test.exs
@@ -107,7 +107,7 @@ defmodule TripUpdatesTest do
         stop_id: "stop",
         stop_sequence: 5,
         status: :all_aboard,
-        track: "track"
+        track: "5"
       }
       assert stop_time_update(status) == %{
         stop_id: "stop",
@@ -116,7 +116,8 @@ defmodule TripUpdatesTest do
           time: 12_345
         },
         boarding_status: "ALL_ABOARD",
-        platform_id: "track"
+        platform_id: "stop-05",
+        track: "5"
       }
     end
 


### PR DESCRIPTION
At some point, we'll need to have this look up the platform_id from the API,
but it's not in a GTFS file yet. I'm also keeping the actual track
information around for the time being.