### PR TITLE
correctly convert UTC datetimes to service dates

### DIFF
--- a/lib/date_helpers.ex
+++ b/lib/date_helpers.ex
@@ -19,6 +19,7 @@ defmodule DateHelpers do
 
   def service_date(%DateTime{} = dt) do
     dt
+    |> ensure_timezone(@timezone)
     |> Calendar.DateTime.subtract!(@three_hours_in_seconds)
     |> DateTime.to_date()
   end
@@ -47,5 +48,14 @@ defmodule DateHelpers do
     # microseconds. the negatives make sure we floor towards
     # negative-infinity (getting a larger number)
     -Integer.floor_div(seconds * 1_000_000 + microseconds, -1_000_000)
+  end
+
+  defp ensure_timezone(%DateTime{time_zone: timezone} = dt, timezone) do
+    # already in the right timezone
+    dt
+  end
+
+  defp ensure_timezone(dt, timezone) do
+    Calendar.DateTime.shift_zone!(dt, timezone)
   end
 end

--- a/lib/trip_updates.ex
+++ b/lib/trip_updates.ex
@@ -8,7 +8,7 @@ defmodule TripUpdates do
   """
 
   def to_map(boarding_statuses) do
-    current_time = DateTime.to_unix(DateTime.utc_now())
+    current_time = System.system_time(:seconds)
 
     %{
       header: header(current_time),
@@ -50,8 +50,8 @@ defmodule TripUpdates do
   def trip(%BoardingStatus{} = bs) do
     start_date =
       case bs.scheduled_time do
-        :unknown -> Date.utc_today()
-        dt -> DateTime.to_date(dt)
+        :unknown -> DateHelpers.service_date()
+        dt -> DateHelpers.service_date(dt)
       end
 
     Map.merge(

--- a/test/trip_updates_test.exs
+++ b/test/trip_updates_test.exs
@@ -69,7 +69,7 @@ defmodule TripUpdatesTest do
   describe "trip/1" do
     test "builds trip information from the status" do
       status = %BoardingStatus{
-        scheduled_time: DateTime.from_naive!(~N[2017-02-05T05:06:07], "Etc/UTC"),
+        scheduled_time: DateTime.from_naive!(~N[2017-02-05T09:10:11], "Etc/UTC"),
         route_id: "route",
         trip_id: "trip",
         direction_id: 1
@@ -101,6 +101,23 @@ defmodule TripUpdatesTest do
       }
 
       assert trip(status).schedule_relationship == "CANCELED"
+    end
+
+    test "uses the previous day's date if the service is before 3am Eastern" do
+      eastern_time =
+        Calendar.DateTime.from_date_and_time_and_zone!(
+          ~D[2018-03-20],
+          ~T[02:00:00],
+          "America/New_York"
+        )
+
+      utc_time = Calendar.DateTime.shift_zone!(eastern_time, "Etc/UTC")
+
+      status = %BoardingStatus{
+        scheduled_time: utc_time
+      }
+
+      assert %{start_date: ~D[2018-03-19]} = trip(status)
     end
   end
 


### PR DESCRIPTION
Previously, we weren't doing the conversion at all for the `start_date` field
in the output, and we weren't correctly handling the timezone offsets. This
PR addresses both.