### PR TITLE
fix: filter out maps with status "Bus substitute" or "Not stopping here"

### DIFF
--- a/apps/commuter_rail_boarding/lib/boarding_status.ex
+++ b/apps/commuter_rail_boarding/lib/boarding_status.ex
@@ -69,6 +69,7 @@ defmodule BoardingStatus do
       ) do
     with :ok <- validate_movement_type(map),
          :ok <- validate_is_stopping(map),
+         :ok <- validate_status(status),
          {:ok, scheduled_time, _} <- DateTime.from_iso8601(schedule_time_iso),
          {:ok, trip_id, route_id, direction_id, added?} <-
            trip_route_direction_id(map, scheduled_time) do
@@ -132,6 +133,15 @@ defmodule BoardingStatus do
   # We can ignore any object with is_Stopping False
   def validate_is_stopping(%{"is_Stopping" => "False"}), do: :ignore
   def validate_is_stopping(_), do: :ok
+
+  # Ignore statuses "Bus substitution" and "Not stopping here"
+  def validate_status(status) do
+    case status_string(status) do
+      "Bus substitution" -> :ignore
+      "Not stopping here" -> :ignore
+      _ -> :ok
+    end
+  end
 
   defp trip_route_direction_id(
          %{

--- a/apps/commuter_rail_boarding/test/boarding_status_test.exs
+++ b/apps/commuter_rail_boarding/test/boarding_status_test.exs
@@ -169,5 +169,15 @@ defmodule BoardingStatusTest do
 
       assert :ignore = from_firebase(result)
     end
+
+    test "ignores items with bad status" do
+      original = List.first(@results)
+      result = Map.put(original, "status", "BS")
+      assert :ignore = from_firebase(result)
+      result = Map.put(original, "status", "GL")
+      assert :ignore = from_firebase(result)
+      result = Map.put(original, "status", "BL")
+      assert :ignore = from_firebase(result)
+    end
   end
 end


### PR DESCRIPTION
**Asana Ticket:** [CommuterRailBoarding should treat some statuses as is_Stopped=False trip](https://app.asana.com/0/584764604969369/1150523261601642).

- Add check to validate status as well as validating the value of `is_Stopping`.
- Ignore Firebase maps where status maps to either "Bus substitution" or "Not stopping here"