### PR TITLE
chore: update config to substitute new stop_ids

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,8 +3,9 @@ use Mix.Config
 config :commuter_rail_boarding,
   firebase_url: {:system, "CRB_FIREBASE_URL"},
   stop_ids: %{
-    "Boston" => "South Station",
-    "Boston North Station" => "North Station"
+    "South Station" => "NEC-2287",
+    "North Station" => "BNT-0000",
+    "Back Bay" => "NEC-2276"
   },
   headsigns: %{
     "Forge Park/495" => "Forge Park / 495",


### PR DESCRIPTION
Asana ticket: [🚂 Prepare commuter_rail_boarding to handle new platforms](https://app.asana.com/0/584764604969369/1188089353569009/f)

Just adding ids to a config variable that then are substituted into the feed by https://github.com/mbta/commuter_rail_boarding/blob/fl/new-ids/apps/commuter_rail_boarding/lib/boarding_status.ex#L231 