### PR TITLE
feat: log when refreshing SSE connection

### DIFF
--- a/apps/train_loc/lib/train_loc/manager.ex
+++ b/apps/train_loc/lib/train_loc/manager.ex
@@ -115,6 +115,8 @@ defmodule TrainLoc.Manager do
   end
 
   def handle_info(:timeout, state) do
+    Logger.warn(fn -> "#{__MODULE__}: Connection timed out, refreshing..." end)
+
     Enum.each(state.producers, state.refresh_fn)
 
     state = schedule_timeout(state)

--- a/apps/train_loc/test/train_loc/manager_test.exs
+++ b/apps/train_loc/test/train_loc/manager_test.exs
@@ -42,9 +42,14 @@ defmodule TrainLoc.ManagerTest do
     test ":timeout refreshes the connection" do
       state = %Manager{producers: [:x], refresh_fn: &__MODULE__.send_self/1}
 
-      Manager.handle_info(:timeout, state)
+      log =
+        capture_log([level: :warn], fn ->
+          Manager.handle_info(:timeout, state)
 
-      assert_received :x
+          assert_received :x
+        end)
+
+      assert log =~ "Connection timed out, refreshing..."
     end
   end
 


### PR DESCRIPTION
Ticket: [🐛 investigate: TrainLoc/CRB stale timestamps Dec 12](https://app.asana.com/0/584764604969369/1199599953437141/f)

Upon further investigation, it seems that the `TrainLoc.Manager` GenServer didn't receive any SSE events for an extended period of time on the 12th leading up to the moment that Dan bounced it. There is _supposed_ to be logic that refreshes the connection if an event hasn't been received in 5 minutes. I looked it over to see if there were any obvious reasons it wouldn't work, but couldn't find any, and the functionality does have test coverage. Per earlier discussion though I think we can add some logging around when the refresh is supposed to happen, so in the future we'll be able to investigate whether or not the refresh was triggered and narrow things down from there.