### PR TITLE
build: don't install awscli via pip, use Semaphore version instead

### DIFF
--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -3,8 +3,6 @@ set -e -x -u
 #!/bin/bash
 set -e -u
 
-sudo pip install -U awscli
-
 # bash script should be called with aws environment ($APP-dev / $APP-dev-green / $APP-prod)
 # other required configuration:
 # * APP


### PR DESCRIPTION
Same issue I just ran into with parking tweets and concentrate.