### PR TITLE
fix: use correct stop ID for Back Bay tracks 5+7

### DIFF
--- a/apps/commuter_rail_boarding/lib/boarding_status.ex
+++ b/apps/commuter_rail_boarding/lib/boarding_status.ex
@@ -74,7 +74,7 @@ defmodule BoardingStatus do
          {:ok, scheduled_time, _} <- DateTime.from_iso8601(schedule_time_iso),
          {:ok, trip_id, route_id, direction_id, added?} <-
            trip_route_direction_id(map, scheduled_time) do
-      stop_id = stop_id(stop_name)
+      stop_id = stop_id(stop_name, track)
 
       {:ok,
        %__MODULE__{
@@ -226,8 +226,12 @@ route #{route_id}, name #{trip_name}, trip ID #{keolis_trip_id}"
     end
   end
 
-  def stop_id(stop_name) do
-    Map.get(config(:stop_ids), stop_name, stop_name)
+  def stop_id(stop_name, track) do
+    case Map.get(config(:stop_ids), stop_name) do
+      nil -> stop_name
+      stop_id when is_binary(stop_id) -> stop_id
+      stop_ids when is_map(stop_ids) -> Map.get(stop_ids, track, stop_name)
+    end
   end
 
   statuses = Application.get_env(:commuter_rail_boarding, :statuses)

--- a/apps/commuter_rail_boarding/test/boarding_status_test.exs
+++ b/apps/commuter_rail_boarding/test/boarding_status_test.exs
@@ -94,6 +94,15 @@ defmodule BoardingStatusTest do
       assert from_firebase(result) == from_firebase(original)
     end
 
+    test "assigns a stop ID based on the track number for Back Bay" do
+      original = List.first(@results)
+      track1 = %{original | "gtfs_stop_name" => "Back Bay", "track" => "1"}
+      track5 = %{original | "gtfs_stop_name" => "Back Bay", "track" => "5"}
+
+      assert {:ok, %{stop_id: "NEC-2276"}} = from_firebase(track1)
+      assert {:ok, %{stop_id: "WML-0012"}} = from_firebase(track5)
+    end
+
     test "logs a warning if we have a non-matched trip short name but no trip ID" do
       original = List.first(@results)
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,13 @@ config :commuter_rail_boarding,
   stop_ids: %{
     "South Station" => "NEC-2287",
     "North Station" => "BNT-0000",
-    "Back Bay" => "NEC-2276",
+    "Back Bay" => %{
+      "1" => "NEC-2276",
+      "2" => "NEC-2276",
+      "3" => "NEC-2276",
+      "5" => "WML-0012",
+      "7" => "WML-0012"
+    },
     "Ruggles" => "NEC-2265"
   },
   headsigns: %{


### PR DESCRIPTION
**Asana:** [🚂🐛 Correct stop ID for Back Bay CR status](https://app.asana.com/0/584764604969369/1201477394801610)

Since Commuter Rail stop IDs are now based on track distance markers, the stop ID prefix for tracks 5 and 7 at Back Bay is different from the others, because these tracks are on a physically separate branch. This fixes boarding status not being available for Worcester Line trains (which use these tracks) because we were publishing it under the wrong stop IDs.