### PR TITLE
fix: bad stop ID for Back Bay status with no track

### DIFF
--- a/apps/commuter_rail_boarding/test/boarding_status_test.exs
+++ b/apps/commuter_rail_boarding/test/boarding_status_test.exs
@@ -94,11 +94,32 @@ defmodule BoardingStatusTest do
       assert from_firebase(result) == from_firebase(original)
     end
 
+    test "assigns a stop ID based on the stop name" do
+      original = List.first(@results)
+
+      no_track = %{
+        original
+        | "gtfs_stop_name" => "North Station",
+          "track" => ""
+      }
+
+      with_track = %{
+        original
+        | "gtfs_stop_name" => "North Station",
+          "track" => "1"
+      }
+
+      assert {:ok, %{stop_id: "BNT-0000"}} = from_firebase(no_track)
+      assert {:ok, %{stop_id: "BNT-0000"}} = from_firebase(with_track)
+    end
+
     test "assigns a stop ID based on the track number for Back Bay" do
       original = List.first(@results)
+      no_track = %{original | "gtfs_stop_name" => "Back Bay", "track" => ""}
       track1 = %{original | "gtfs_stop_name" => "Back Bay", "track" => "1"}
       track5 = %{original | "gtfs_stop_name" => "Back Bay", "track" => "5"}
 
+      assert {:ok, %{stop_id: "NEC-2276"}} = from_firebase(no_track)
       assert {:ok, %{stop_id: "NEC-2276"}} = from_firebase(track1)
       assert {:ok, %{stop_id: "WML-0012"}} = from_firebase(track5)
     end

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,11 +1,18 @@
 use Mix.Config
 
+# Mapping of `gtfs_stop_name` values to stop IDs. Note these are expected to be valid *both* on
+# their own, and when a track number is appended, if the boarding status has a track assignment
+# (see `TripUpdates.platform_id_map/2`).
+#
+# When the value is a map, this maps specific track numbers to stop IDs. The key `""` must be
+# present to account for boarding statuses with no track assignment. Only the `""` stop ID needs
+# to be valid on its own.
 config :commuter_rail_boarding,
-  firebase_url: {:system, "CRB_FIREBASE_URL"},
   stop_ids: %{
     "South Station" => "NEC-2287",
     "North Station" => "BNT-0000",
     "Back Bay" => %{
+      "" => "NEC-2276",
       "1" => "NEC-2276",
       "2" => "NEC-2276",
       "3" => "NEC-2276",
@@ -13,7 +20,10 @@ config :commuter_rail_boarding,
       "7" => "WML-0012"
     },
     "Ruggles" => "NEC-2265"
-  },
+  }
+
+config :commuter_rail_boarding,
+  firebase_url: {:system, "CRB_FIREBASE_URL"},
   headsigns: %{
     "Forge Park/495" => "Forge Park / 495",
     "Anderson/Woburn" => "Anderson / Woburn",


### PR DESCRIPTION
The fix in 11b3f72 accidentally created a larger issue where Back Bay boarding statuses with _no_ track assignment would cause the stop ID lookup to fail, resulting in an update being published with the stop ID set to `Back Bay`, the original "stop name" value.

This fixes that issue, as well as another issue where the stop sequence would not have been correct for Back Bay tracks 5+7 updates. Some tests and documentation of the `stop_ids` config value are also added.

### Validation

This branch is deployed to dev. Compare:

* https://api-v3.mbta.com/predictions?filter[route]=CR-Worcester&filter[direction_id]=0
* https://api-v3.mbta.com/predictions?filter[route]=CR-Needham&filter[direction_id]=0
* https://dev.api.mbtace.com/predictions?filter[route]=CR-Worcester&filter[direction_id]=0
* https://dev.api.mbtace.com/predictions?filter[route]=CR-Needham&filter[direction_id]=0

Search for `NEC-2276`, `WML-0012`, and `Back Bay`. Confirm that A) the latter does not appear in any predictions, B) instances of `NEC-2276-05` or `-07` in prod are now `WML-0012-xx` in dev (this was the original issue).