### PR TITLE
refactor: use default line length for `mix format`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,4 @@
 # Used by "mix format"
 [
-
-  inputs: ["mix.exs", "config/config.exs", "apps/*/{config,lib,test}/**/*.{ex,exs}"],
-  line_length: 80,
+  inputs: ["*.exs", "config/*.exs", "apps/*/{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/apps/commuter_rail_boarding/lib/boarding_status.ex
+++ b/apps/commuter_rail_boarding/lib/boarding_status.ex
@@ -77,8 +77,7 @@ defmodule BoardingStatus do
       {:ok,
        %__MODULE__{
          scheduled_time: scheduled_time,
-         predicted_time:
-           predicted_time(predicted_time_iso, scheduled_time, status),
+         predicted_time: predicted_time(predicted_time_iso, scheduled_time, status),
          route_id: route_id,
          trip_id: trip_id,
          stop_id: stop_id(stop_name, track),
@@ -155,9 +154,7 @@ defmodule BoardingStatus do
          },
          dt
        ) do
-    {:ok, trip_id, direction_id, added?} =
-      create_trip_id(route_id, trip_name, keolis_trip_id, dt)
-
+    {:ok, trip_id, direction_id, added?} = create_trip_id(route_id, trip_name, keolis_trip_id, dt)
     {:ok, trip_id, route_id, direction_id, added?}
   end
 

--- a/apps/commuter_rail_boarding/lib/commuter_rail_boarding/application.ex
+++ b/apps/commuter_rail_boarding/lib/commuter_rail_boarding/application.ex
@@ -22,9 +22,7 @@ defmodule CommuterRailBoarding.Application do
     children = [
       TripCache,
       ScheduleCache
-      | other_children(
-          Application.get_env(:commuter_rail_boarding, :start_children?)
-        )
+      | other_children(Application.get_env(:commuter_rail_boarding, :start_children?))
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -35,15 +33,13 @@ defmodule CommuterRailBoarding.Application do
 
   defp other_children(true) do
     [
-      {ServerSentEventStage,
-       name: ServerSentEventStage, url: {FirebaseUrl, :url, []}},
+      {ServerSentEventStage, name: ServerSentEventStage, url: {FirebaseUrl, :url, []}},
       {BoardingStatus.ProducerConsumer,
        name: BoardingStatus.ProducerConsumer,
        dispatcher: GenStage.BroadcastDispatcher,
        subscribe_to: [ServerSentEventStage]},
       {TripUpdates.ProducerConsumer,
-       name: TripUpdates.ProducerConsumer,
-       subscribe_to: [BoardingStatus.ProducerConsumer]},
+       name: TripUpdates.ProducerConsumer, subscribe_to: [BoardingStatus.ProducerConsumer]},
       {Uploader.Consumer,
        name: Uploader.Consumer,
        subscribe_to: [

--- a/apps/commuter_rail_boarding/lib/date_helpers.ex
+++ b/apps/commuter_rail_boarding/lib/date_helpers.ex
@@ -42,8 +42,7 @@ defmodule DateHelpers do
         @timezone
       )
 
-    microseconds =
-      DateTime.diff(next_service_start, DateTime.utc_now(), :microsecond)
+    microseconds = DateTime.diff(next_service_start, DateTime.utc_now(), :microsecond)
 
     # we want to return an integer, so we floor_div the seconds +
     # microseconds. the negatives make sure we floor towards

--- a/apps/commuter_rail_boarding/lib/trip_cache.ex
+++ b/apps/commuter_rail_boarding/lib/trip_cache.ex
@@ -92,8 +92,8 @@ defmodule TripCache do
            "attributes" => attributes
          }
        }) do
-    {:ok, relationships["route"]["data"]["id"], attributes["direction_id"],
-     attributes["name"], attributes["headsign"]}
+    {:ok, relationships["route"]["data"]["id"], attributes["direction_id"], attributes["name"],
+     attributes["headsign"]}
   end
 
   defp decode_single_trip(%{"data" => []}) do
@@ -139,10 +139,7 @@ defmodule TripCache do
   defp decode_trips(%{"data" => data}) when is_list(data) do
     {:ok,
      for trip <- data do
-       key =
-         {:route, trip["relationships"]["route"]["data"]["id"],
-          trip["attributes"]["name"]}
-
+       key = {:route, trip["relationships"]["route"]["data"]["id"], trip["attributes"]["name"]}
        {key, trip["id"], trip["attributes"]["direction_id"]}
      end}
   end

--- a/apps/commuter_rail_boarding/test/boarding_status_test.exs
+++ b/apps/commuter_rail_boarding/test/boarding_status_test.exs
@@ -96,18 +96,8 @@ defmodule BoardingStatusTest do
 
     test "assigns a stop ID based on the stop name" do
       original = List.first(@results)
-
-      no_track = %{
-        original
-        | "gtfs_stop_name" => "North Station",
-          "track" => ""
-      }
-
-      with_track = %{
-        original
-        | "gtfs_stop_name" => "North Station",
-          "track" => "1"
-      }
+      no_track = %{original | "gtfs_stop_name" => "North Station", "track" => ""}
+      with_track = %{original | "gtfs_stop_name" => "North Station", "track" => "1"}
 
       assert {:ok, %{stop_id: "BNT-0000"}} = from_firebase(no_track)
       assert {:ok, %{stop_id: "BNT-0000"}} = from_firebase(with_track)

--- a/apps/commuter_rail_boarding/test/commuter_rail_boarding/application_test.exs
+++ b/apps/commuter_rail_boarding/test/commuter_rail_boarding/application_test.exs
@@ -3,9 +3,7 @@ defmodule CommuterRailBoarding.ApplicationTest do
   use ExUnit.Case
 
   setup do
-    start_children? =
-      Application.get_env(:commuter_rail_boarding, :start_children?)
-
+    start_children? = Application.get_env(:commuter_rail_boarding, :start_children?)
     Application.put_env(:commuter_rail_boarding, :start_children?, true)
 
     on_exit(fn ->

--- a/apps/commuter_rail_boarding/test/trip_cache_test.exs
+++ b/apps/commuter_rail_boarding/test/trip_cache_test.exs
@@ -29,8 +29,7 @@ defmodule TripCacheTest do
 
     test "correctly finds a trip ID based on the date passed in" do
       # find the next Saturday
-      day_of_week =
-        @datetime |> DateHelpers.service_date() |> Date.day_of_week()
+      day_of_week = @datetime |> DateHelpers.service_date() |> Date.day_of_week()
 
       unix = DateTime.to_unix(@datetime)
       unix_saturday = unix + 86_400 * (6 - day_of_week)

--- a/apps/commuter_rail_boarding/test/trip_updates_test.exs
+++ b/apps/commuter_rail_boarding/test/trip_updates_test.exs
@@ -58,9 +58,7 @@ defmodule TripUpdatesTest do
     end
 
     test "builds a trip_update for the statuses" do
-      assert [update] =
-               trip_update(1234, [%BoardingStatus{}, %BoardingStatus{}])
-
+      assert [update] = trip_update(1234, [%BoardingStatus{}, %BoardingStatus{}])
       assert %{} = update.trip_update.trip
       assert [%{}, %{}] = update.trip_update.stop_time_update
     end
@@ -69,8 +67,7 @@ defmodule TripUpdatesTest do
   describe "trip/1" do
     test "builds trip information from the status" do
       status = %BoardingStatus{
-        scheduled_time:
-          DateTime.from_naive!(~N[2017-02-05T09:10:11], "Etc/UTC"),
+        scheduled_time: DateTime.from_naive!(~N[2017-02-05T09:10:11], "Etc/UTC"),
         route_id: "route",
         trip_id: "trip",
         direction_id: 1

--- a/apps/train_loc/lib/train_loc.ex
+++ b/apps/train_loc/lib/train_loc.ex
@@ -12,13 +12,10 @@ defmodule TrainLoc do
   def env, do: @env
 
   def start(_type, _args) do
-    children =
-      [
-        TrainLoc.Supervisor
-      ] ++
-        start_children(
-          Application.get_env(:train_loc, APIFetcher)[:connect_at_startup?]
-        )
+    children = [
+      TrainLoc.Supervisor
+      | start_children(Application.get_env(:train_loc, APIFetcher)[:connect_at_startup?])
+    ]
 
     _ = Logger.info(fn -> "Starting main TrainLoc supervisor..." end)
     opts = [strategy: :one_for_all, name: __MODULE__]
@@ -28,10 +25,8 @@ defmodule TrainLoc do
   defp start_children(true) do
     [
       {ServerSentEventStage,
-       name: TrainLoc.Input.APIFetcher,
-       url: {TrainLoc.Utilities.FirebaseUrl, :url, []}},
-      {TrainLoc.Manager,
-       name: TrainLoc.Manager, subscribe_to: TrainLoc.Input.APIFetcher}
+       name: TrainLoc.Input.APIFetcher, url: {TrainLoc.Utilities.FirebaseUrl, :url, []}},
+      {TrainLoc.Manager, name: TrainLoc.Manager, subscribe_to: TrainLoc.Input.APIFetcher}
     ]
   end
 

--- a/apps/train_loc/lib/train_loc/conflicts/conflicts.ex
+++ b/apps/train_loc/lib/train_loc/conflicts/conflicts.ex
@@ -28,11 +28,8 @@ defmodule TrainLoc.Conflicts.Conflicts do
   """
   @spec diff(conflicts_acc, conflicts_acc) :: {conflicts_acc, conflicts_acc}
   def diff(pre_existing_conflicts, current_conflicts) do
-    new_conflicts =
-      filter_only_unknown(pre_existing_conflicts, current_conflicts)
-
-    removed_conflicts =
-      filter_only_removed(pre_existing_conflicts, current_conflicts)
+    new_conflicts = filter_only_unknown(pre_existing_conflicts, current_conflicts)
+    removed_conflicts = filter_only_removed(pre_existing_conflicts, current_conflicts)
 
     {removed_conflicts, new_conflicts}
   end

--- a/apps/train_loc/lib/train_loc/manager.ex
+++ b/apps/train_loc/lib/train_loc/manager.ex
@@ -66,8 +66,7 @@ defmodule TrainLoc.Manager do
         time_baseline: time_baseline_fn,
         excluded_vehicles: excluded_vehicles,
         producers: producers,
-        timeout_after:
-          Keyword.get(opts, :timeout_after, %__MODULE__{}.timeout_after)
+        timeout_after: Keyword.get(opts, :timeout_after, %__MODULE__{}.timeout_after)
       })
 
     {:consumer, state, subscribe_to: producers}

--- a/apps/train_loc/lib/train_loc/vehicles/vehicle.ex
+++ b/apps/train_loc/lib/train_loc/vehicles/vehicle.ex
@@ -101,8 +101,7 @@ defmodule TrainLoc.Vehicles.Vehicle do
   def log_vehicle(vehicle) do
     _ =
       Logger.debug(fn ->
-        Enum.reduce(Map.from_struct(vehicle), "Vehicle - ", fn {key, value},
-                                                               acc ->
+        Enum.reduce(Map.from_struct(vehicle), "Vehicle - ", fn {key, value}, acc ->
           acc <> format_key_value_pair(key, value)
         end)
       end)

--- a/apps/train_loc/test/integration/scenarios/one_minute.ex
+++ b/apps/train_loc/test/integration/scenarios/one_minute.ex
@@ -112,8 +112,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.07462,
         trip: "000",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:30 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:30 America/New_York", time_format),
         vehicle_id: 1625,
         block: "000"
       },
@@ -123,8 +122,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.07749,
         trip: "000",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:30 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:30 America/New_York", time_format),
         vehicle_id: 1626,
         block: "000"
       },
@@ -134,8 +132,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.07744,
         trip: "000",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:31 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:31 America/New_York", time_format),
         vehicle_id: 1627,
         block: "000"
       },
@@ -145,8 +142,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.06314,
         trip: "168",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:18 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:18 America/New_York", time_format),
         vehicle_id: 1628,
         block: "402"
       },
@@ -156,8 +152,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.06286,
         trip: "214",
         speed: 2,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:37 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:37 America/New_York", time_format),
         vehicle_id: 1629,
         block: "300"
       },
@@ -167,8 +162,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.07522,
         trip: "000",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:31 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:31 America/New_York", time_format),
         vehicle_id: 1630,
         block: "000"
       },
@@ -178,8 +172,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.06332,
         trip: "324",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:19:15 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:19:15 America/New_York", time_format),
         vehicle_id: 1631,
         block: "200"
       },
@@ -189,8 +182,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.07494,
         trip: "000",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:21 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:21 America/New_York", time_format),
         vehicle_id: 1632,
         block: "000"
       },
@@ -200,8 +192,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -70.87048,
         trip: "116",
         speed: 19,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:33 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:33 America/New_York", time_format),
         vehicle_id: 1633,
         block: "104"
       },
@@ -211,8 +202,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.11536,
         trip: "321",
         speed: 30,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:25 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:25 America/New_York", time_format),
         vehicle_id: 1636,
         block: "200"
       },
@@ -222,8 +212,7 @@ defmodule TrainLoc.IntegrationTest.Scenarios.OneMinute do
         longitude: -71.07525,
         trip: "000",
         speed: 0,
-        timestamp:
-          Timex.parse!("2018-01-29 14:23:25 America/New_York", time_format),
+        timestamp: Timex.parse!("2018-01-29 14:23:25 America/New_York", time_format),
         vehicle_id: 1637,
         block: "000"
       }

--- a/apps/train_loc/test/train_loc/conflicts/conflicts_test.exs
+++ b/apps/train_loc/test/train_loc/conflicts/conflicts_test.exs
@@ -235,8 +235,7 @@ defmodule TrainLoc.Conflicts.ConflictsTest do
     refute Conflicts.contains_conflict?(filtered_by_trip, conflict2)
     refute Conflicts.contains_conflict?(filtered_by_trip, conflict3)
 
-    filtered_by_date =
-      Conflicts.filter_by(conflicts, :service_date, ~D[2017-09-02])
+    filtered_by_date = Conflicts.filter_by(conflicts, :service_date, ~D[2017-09-02])
 
     assert Conflicts.contains_conflict?(filtered_by_date, conflict1)
     assert Conflicts.contains_conflict?(filtered_by_date, conflict2)

--- a/apps/train_loc/test/train_loc/encoder/vehicle_positions_enhanced_test.exs
+++ b/apps/train_loc/test/train_loc/encoder/vehicle_positions_enhanced_test.exs
@@ -130,33 +130,13 @@ defmodule TrainLoc.Encoder.VehiclePositionsEnhancedTest do
 
     test "converts UTC datestimes into service data around DST transitions" do
       # spring forward
-      assert start_date(
-               DateTime.from_naive!(~N[2018-03-11T06:59:59], "Etc/UTC")
-             ) == "20180310"
-
-      assert start_date(
-               DateTime.from_naive!(~N[2018-03-11T07:00:00], "Etc/UTC")
-             ) == "20180311"
-
-      assert start_date(
-               DateTime.from_naive!(~N[2018-03-11T08:30:00], "Etc/UTC")
-             ) == "20180311"
-
-      assert start_date(
-               DateTime.from_naive!(~N[2018-11-04T06:59:59], "Etc/UTC")
-             ) == "20181103"
-
-      assert start_date(
-               DateTime.from_naive!(~N[2018-11-04T07:00:00], "Etc/UTC")
-             ) == "20181103"
-
-      assert start_date(
-               DateTime.from_naive!(~N[2018-11-04T08:30:00], "Etc/UTC")
-             ) == "20181104"
-
-      assert start_date(
-               DateTime.from_naive!(~N[2018-11-04T09:30:00], "Etc/UTC")
-             ) == "20181104"
+      assert start_date(DateTime.from_naive!(~N[2018-03-11T06:59:59], "Etc/UTC")) == "20180310"
+      assert start_date(DateTime.from_naive!(~N[2018-03-11T07:00:00], "Etc/UTC")) == "20180311"
+      assert start_date(DateTime.from_naive!(~N[2018-03-11T08:30:00], "Etc/UTC")) == "20180311"
+      assert start_date(DateTime.from_naive!(~N[2018-11-04T06:59:59], "Etc/UTC")) == "20181103"
+      assert start_date(DateTime.from_naive!(~N[2018-11-04T07:00:00], "Etc/UTC")) == "20181103"
+      assert start_date(DateTime.from_naive!(~N[2018-11-04T08:30:00], "Etc/UTC")) == "20181104"
+      assert start_date(DateTime.from_naive!(~N[2018-11-04T09:30:00], "Etc/UTC")) == "20181104"
     end
   end
 

--- a/apps/train_loc/test/train_loc/manager/event_test.exs
+++ b/apps/train_loc/test/train_loc/manager/event_test.exs
@@ -28,8 +28,7 @@ defmodule TrainLoc.Manager.EventTest do
         }
       })
 
-    assert {:ok, %Event{vehicles_json: result, date: nil}} =
-             Event.from_string(raw_vehicle_json)
+    assert {:ok, %Event{vehicles_json: result, date: nil}} = Event.from_string(raw_vehicle_json)
 
     assert length(result) == 2
     assert TestHelpers.match_any?(%{"VehicleID" => 1633}, result)

--- a/apps/train_loc/test/train_loc/utilities/time_test.exs
+++ b/apps/train_loc/test/train_loc/utilities/time_test.exs
@@ -44,9 +44,7 @@ defmodule TrainLoc.Utilities.TimeTest do
 
       micro_string = "2018-03-28T01:23:45.678910Z"
       micro_actual = parse_improper_iso(micro_string, @timezone)
-
-      micro_expected =
-        Timex.to_datetime(~N[2018-03-28T01:23:45.678910], @timezone)
+      micro_expected = Timex.to_datetime(~N[2018-03-28T01:23:45.678910], @timezone)
 
       assert micro_actual == micro_expected
     end

--- a/apps/train_loc/test/train_loc/vehicles/validator_test.exs
+++ b/apps/train_loc/test/train_loc/vehicles/validator_test.exs
@@ -63,22 +63,19 @@ defmodule TrainLoc.Vehicles.ValidatorTest do
     test "errors non-floats" do
       veh = %Vehicle{latitude: :atom, vehicle_id: 1}
 
-      assert {:error, :invalid_vehicle} =
-               Validator.must_have_valid_latitude(veh)
+      assert {:error, :invalid_vehicle} = Validator.must_have_valid_latitude(veh)
     end
 
     test "errors for high values" do
       veh = %Vehicle{latitude: 44.6, vehicle_id: 1}
 
-      assert {:error, :invalid_vehicle} =
-               Validator.must_have_valid_latitude(veh)
+      assert {:error, :invalid_vehicle} = Validator.must_have_valid_latitude(veh)
     end
 
     test "errors for low values" do
       veh = %Vehicle{latitude: 32.0, vehicle_id: 1}
 
-      assert {:error, :invalid_vehicle} =
-               Validator.must_have_valid_latitude(veh)
+      assert {:error, :invalid_vehicle} = Validator.must_have_valid_latitude(veh)
     end
   end
 
@@ -96,22 +93,19 @@ defmodule TrainLoc.Vehicles.ValidatorTest do
     test "errors non-floats" do
       veh = %Vehicle{longitude: :atom, vehicle_id: 1}
 
-      assert {:error, :invalid_vehicle} =
-               Validator.must_have_valid_longitude(veh)
+      assert {:error, :invalid_vehicle} = Validator.must_have_valid_longitude(veh)
     end
 
     test "errors for high values" do
       veh = %Vehicle{longitude: -68.0, vehicle_id: 1}
 
-      assert {:error, :invalid_vehicle} =
-               Validator.must_have_valid_longitude(veh)
+      assert {:error, :invalid_vehicle} = Validator.must_have_valid_longitude(veh)
     end
 
     test "errors for low values" do
       veh = %Vehicle{longitude: -73.0, vehicle_id: 1}
 
-      assert {:error, :invalid_vehicle} =
-               Validator.must_have_valid_longitude(veh)
+      assert {:error, :invalid_vehicle} = Validator.must_have_valid_longitude(veh)
     end
   end
 


### PR DESCRIPTION
The default line length for the formatter is 98 characters. This aligns with our other projects. ([context](https://github.com/mbta/commuter_rail_boarding/pull/160#discussion_r778391215))

I thought the formatter never touched existing newlines, but it turns out it will collapse them in some situations if the result would fit within the line length ("split" assignments and key/values are a common theme). So this is a larger diff than I expected, despite mostly just being the result of re-running `mix format` with the new line length.

The only extra things done are:
* removing some blank lines around now-single-line expressions that seemed like they were previously introduced by the formatter's requirement to surround multi-line expressions with blank lines
* using list prepend instead of concatenation in one spot in `TrainLoc` where it resulted in cleaner formatting