### PR TITLE
fix: Don't manually specify 'unassigned' as assignment_status

### DIFF
--- a/apps/train_loc/lib/train_loc/encoder/vehicle_positions_enhanced.ex
+++ b/apps/train_loc/lib/train_loc/encoder/vehicle_positions_enhanced.ex
@@ -100,13 +100,6 @@ defmodule TrainLoc.Encoder.VehiclePositionsEnhanced do
   end
 
   @spec entity_vehicle(Vehicle.t()) :: entity_vehicle()
-  defp entity_vehicle(%{trip: :unassigned} = vehicle) do
-    %{
-      id: vehicle.vehicle_id,
-      assignment_status: "unassigned"
-    }
-  end
-
   defp entity_vehicle(vehicle) do
     %{
       id: vehicle.vehicle_id

--- a/apps/train_loc/test/train_loc/encoder/vehicle_positions_enhanced_test.exs
+++ b/apps/train_loc/test/train_loc/encoder/vehicle_positions_enhanced_test.exs
@@ -118,18 +118,6 @@ defmodule TrainLoc.Encoder.VehiclePositionsEnhancedTest do
       assert Map.has_key?(vehicle_1["vehicle"]["trip"], "trip_short_name")
       refute Map.has_key?(vehicle_2["vehicle"]["trip"], "trip_short_name")
       refute Map.has_key?(vehicle_3["vehicle"]["trip"], "trip_short_name")
-
-      assert %{
-               "vehicle" => %{
-                 "vehicle" => %{"assignment_status" => "unassigned"}
-               }
-             } = vehicle_2
-
-      assert %{
-               "vehicle" => %{
-                 "vehicle" => %{"assignment_status" => "unassigned"}
-               }
-             } = vehicle_3
     end
   end
 

--- a/apps/train_loc/test/train_loc/manager_test.exs
+++ b/apps/train_loc/test/train_loc/manager_test.exs
@@ -250,7 +250,7 @@ defmodule TrainLoc.ManagerTest do
                    },
                    "timestamp" => 1_642_722_222,
                    "trip" => %{"start_date" => "20220120"},
-                   "vehicle" => %{"assignment_status" => "unassigned", "id" => 1506}
+                   "vehicle" => %{"id" => 1506}
                  }
                },
                %{
@@ -264,7 +264,7 @@ defmodule TrainLoc.ManagerTest do
                    },
                    "timestamp" => 1_642_722_222,
                    "trip" => %{"start_date" => "20220120"},
-                   "vehicle" => %{"assignment_status" => "unassigned", "id" => 1507}
+                   "vehicle" => %{"id" => 1507}
                  }
                },
                %{


### PR DESCRIPTION
Swiftly put in place a special rule for bus, which applies to all modes, where if the underlying data has an explicit 'unassigned' status, then the vehicle cannot be tagged with an overriding assignment on the Swiftly dashboard.

George at Keolis requested this change for the new feed, since they will be using the Swiftly dashboard to tag trips in the event of ACSES fallback.

This has the side effect of re-enabling auto trip assignment, which Keolis now wants.

I'm not clear on how this will affect the *current* prod feed, and am trying to get clarity on that. (i.e.: can this be merged and deployed, or should it be done in tandem with a switch to the new feed?).