### PR TITLE
fix: non-revenue trains not being ignored

### DIFF
--- a/apps/commuter_rail_boarding/lib/boarding_status.ex
+++ b/apps/commuter_rail_boarding/lib/boarding_status.ex
@@ -110,7 +110,7 @@ defmodule BoardingStatus do
     :error
   end
 
-  def validate_movement_type(%{"movement_type" => type})
+  def validate_movement_type(%{"movementtype" => type})
       when type in ~w(O B E) do
     # O - Originating
     # B - Both End Train and Detrain
@@ -118,7 +118,7 @@ defmodule BoardingStatus do
     :ok
   end
 
-  def validate_movement_type(%{"movement_type" => _}) do
+  def validate_movement_type(%{"movementtype" => _}) do
     # other movement types shouldn't get boarding statuses
     :ignore
   end

--- a/apps/commuter_rail_boarding/test/boarding_status_test.exs
+++ b/apps/commuter_rail_boarding/test/boarding_status_test.exs
@@ -15,11 +15,11 @@ defmodule BoardingStatusTest do
            |> Map.get("results")
 
   describe "from_firebase/1" do
-    test "returns {:ok, t} for all items from fixture" do
+    test "returns :ok or :ignore for all items in fixture" do
       refute @results == []
 
       for result <- Task.async_stream(@results, &from_firebase/1) do
-        assert {:ok, {:ok, %BoardingStatus{}}} = result
+        assert match?({:ok, {:ok, %BoardingStatus{}}}, result) or match?({:ok, :ignore}, result)
       end
     end
 
@@ -160,9 +160,9 @@ defmodule BoardingStatusTest do
 
     test "ignores items with the wrong movement type" do
       original = List.first(@results)
-      result = Map.put(original, "movement_type", "")
+      result = Map.put(original, "movementtype", "")
       assert from_firebase(result) == :ignore
-      result = Map.put(original, "movement_type", "O")
+      result = Map.put(original, "movementtype", "O")
       assert {:ok, _} = from_firebase(result)
     end
 


### PR DESCRIPTION
**Asana:** [💳 commuter_rail_boarding movementtype typo](https://app.asana.com/0/584764604969369/1202071146128175)

The property `movementtype` was mistakenly entered as `movement_type`, causing the app to always act as though no movement type had been specified and assume the train was a revenue train.