### PR TITLE
fix: refresh TrainLoc's token when auth_revoked

### DIFF
--- a/apps/train_loc/lib/train_loc/manager.ex
+++ b/apps/train_loc/lib/train_loc/manager.ex
@@ -192,6 +192,7 @@ defmodule TrainLoc.Manager do
          %{producers: producers, refresh_fn: refresh_fn}
        ) do
     if should_refresh?(events) do
+      Logger.info("Reauthenticating to Firebase...")
       Enum.each(producers, refresh_fn)
     end
   end

--- a/apps/train_loc/lib/train_loc/manager.ex
+++ b/apps/train_loc/lib/train_loc/manager.ex
@@ -100,6 +100,7 @@ defmodule TrainLoc.Manager do
   @spec handle_events([term()], GenStage.from() | :from, t()) :: {:noreply, [], t()}
   def handle_events(events, _from, state) do
     state = schedule_timeout(state)
+    maybe_refresh!(events, state)
 
     for event <- events, event.event == "put" do
       Logger.debug(fn ->
@@ -184,5 +185,18 @@ defmodule TrainLoc.Manager do
 
     ref = Process.send_after(self(), :timeout, state.timeout_after)
     %{state | timeout_ref: ref}
+  end
+
+  defp maybe_refresh!(
+         events,
+         %{producers: producers, refresh_fn: refresh_fn}
+       ) do
+    if should_refresh?(events) do
+      Enum.each(producers, refresh_fn)
+    end
+  end
+
+  defp should_refresh?(events) do
+    Enum.any?(events, &(&1.event == "auth_revoked"))
   end
 end


### PR DESCRIPTION
Per discussion in Slack, TrainLoc needs to refresh its Firebase token when it receives the `auth_revoked` event. It seems previously that Firebase would close the connection when the token expired, but they stopped doing this at some point yesterday, causing TrainLoc to stop receiving events hourly and require a restart. `ServerSentEventStage` is injected with `TrainLoc.Utilities.FirebaseUrl.url/0`, causing it to generate a new token when `ServerSentEventStage.refresh/1` is called by `TrainLoc.Manager.handle_events/3`. Note that `BoardingStatus.ProducerConsumer` already handles this properly, this code was adapted from that implementation:

https://github.com/mbta/commuter_rail_boarding/blob/01f4308ecbe5298dacff2281dfc9de78161b76bb/apps/commuter_rail_boarding/lib/boarding_status/producer_consumer.ex#L31-L33