### PR TITLE
feat: set NODE_COOKIE to random string

### DIFF
--- a/rel/config.exs
+++ b/rel/config.exs
@@ -24,7 +24,7 @@ use Distillery.Releases.Config,
 environment :prod do
   set include_erts: true
   set include_src: false
-  set cookie: :"${Base.url_encode64(:crypto.strong_rand_bytes(40))}"
+  set cookie: :"#{Base.url_encode64(:crypto.strong_rand_bytes(40))}"
 end
 
 # You may define one or more releases in this file.

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -24,7 +24,7 @@ use Distillery.Releases.Config,
 environment :prod do
   set include_erts: true
   set include_src: false
-  set cookie: :"${NODE_COOKIE}"
+  set cookie: :"${Base.url_encode64(:crypto.strong_rand_bytes(40))}"
 end
 
 # You may define one or more releases in this file.


### PR DESCRIPTION
Pursuant to mbta/devops#534, sets NODE_COOKIE to a random string because we don't use the one in secrets manager.