### PR TITLE
feat: new deploy workflow for new ECR repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy to ECS (shared)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: master
+
+jobs:
+  call-workflow:
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@main
+    with:
+      app-name: commuter-rail-boarding
+      environment: dev
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      docker-repo: ${{ secrets.NEW_DOCKER_REPO }}
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,21 @@
-name: Deploy to ECS (shared)
+name: Deploy to ECS
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
+        required: true
+        default: dev
   push:
-    branches: master
+    branches: main
 
 jobs:
   call-workflow:
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@main
     with:
       app-name: commuter-rail-boarding
-      environment: dev
+      environment: ${{ github.event.inputs.environment || 'dev' }}
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Dependency of https://app.asana.com/0/584764604969369/1200734194931980/f. Adds a new deploy workflow which calls the reusable workflow and assumes that a different ECR repo secret is present, so we can test a dev deploy without altering prod. After prod is switched over to Terraform and the new repo this workflow will handle deployments to all environments.