### PR TITLE
Fix Sentry configuration

### DIFF
--- a/apps/commuter_rail_boarding/lib/commuter_rail_boarding/application.ex
+++ b/apps/commuter_rail_boarding/lib/commuter_rail_boarding/application.ex
@@ -6,9 +6,6 @@ defmodule CommuterRailBoarding.Application do
   use Application
 
   def start(_type, _args) do
-    # Invoke Sentry logger programmatically to ensure it starts at the correct time:
-    _ = Logger.add_backend(Sentry.LoggerBackend)
-
     Application.put_env(
       :commuter_rail_boarding,
       :v3_api_key,

--- a/apps/commuter_rail_boarding/mix.exs
+++ b/apps/commuter_rail_boarding/mix.exs
@@ -45,7 +45,8 @@ defmodule CommuterRailBoarding.Mixfile do
       {:lcov_ex, "~> 0.2", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:bypass, "~> 2.1", only: :test},
-      {:ehmon, git: "https://github.com/mbta/ehmon.git", tag: "master", only: :prod}
+      {:ehmon, git: "https://github.com/mbta/ehmon.git", tag: "master", only: :prod},
+      {:sentry, "~> 8.0"}
     ]
   end
 

--- a/apps/train_loc/lib/train_loc.ex
+++ b/apps/train_loc/lib/train_loc.ex
@@ -12,8 +12,6 @@ defmodule TrainLoc do
   def env, do: @env
 
   def start(_type, _args) do
-    # Invoke Sentry logger programmatically to ensure it starts at the correct time:
-    _ = Logger.add_backend(Sentry.LoggerBackend)
 
     children = [
       TrainLoc.Supervisor

--- a/apps/train_loc/lib/train_loc.ex
+++ b/apps/train_loc/lib/train_loc.ex
@@ -12,7 +12,6 @@ defmodule TrainLoc do
   def env, do: @env
 
   def start(_type, _args) do
-
     children = [
       TrainLoc.Supervisor
       | start_children(Application.get_env(:train_loc, APIFetcher)[:connect_at_startup?])

--- a/apps/train_loc/mix.exs
+++ b/apps/train_loc/mix.exs
@@ -57,7 +57,8 @@ defmodule TrainLoc.Mixfile do
       {:goth, "~> 1.0"},
       {:jason, "~> 1.1"},
       {:timex, "~> 3.7"},
-      {:ex_json_schema, "~> 0.9.1"}
+      {:ex_json_schema, "~> 0.9.1"},
+      {:sentry, "~> 8.0"}
     ]
   end
 end

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,7 +10,7 @@ config :commuter_rail_boarding, Uploader.S3,
 config :logger,
   truncate: :infinity,
   level: :debug,
-  backends: [:console]
+  backends: [:console, Sentry.LoggerBackend]
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -11,7 +11,11 @@ if is_prod? and is_release? do
       dsn: System.fetch_env!("SENTRY_DSN"),
       environment_name: sentry_env,
       enable_source_code_context: true,
-      root_source_code_path: File.cwd!(),
+      root_source_code_paths: [
+        "#{File.cwd!()}/apps/commuter_rail_boarding",
+        "#{File.cwd!()}/apps/shared",
+        "#{File.cwd!()}/apps/train_loc"
+      ],
       tags: %{
         env: sentry_env
       },

--- a/mix.exs
+++ b/mix.exs
@@ -51,8 +51,7 @@ defmodule LocUmbrella.Mixfile do
   # and cannot be accessed from applications inside the apps folder
   defp deps do
     [
-      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:sentry, "~> 8.0"}
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] fix Sentry config for commuter_rail_boarding](https://app.asana.com/0/584764604969369/1205381214100619/f)

I noticed that Sentry wasn't ingesting any errors in any environments from commuter_rail_boarding. From my testing, having it in the top-level `mix.exs` wouldn't start the Sentry application properly when child apps required it. Adds Sentry as a dependency of both commuter_rail_boarding and train_loc. I also updated `root_source_code_paths` to cover all applications in the umbrella.