### PR TITLE
feat: put files under commuter_rail_boarding in S3

### DIFF
--- a/apps/commuter_rail_boarding/lib/uploader/s3.ex
+++ b/apps/commuter_rail_boarding/lib/uploader/s3.ex
@@ -9,10 +9,11 @@ defmodule Uploader.S3 do
 
   @impl true
   def upload(filename, binary) do
+    full_filename = Path.join("commuter_rail_boarding", filename)
     request =
       S3.put_object(
         config(Uploader.S3, :bucket),
-        filename,
+        full_filename,
         binary,
         acl: :public_read,
         content_type: "application/json"

--- a/apps/commuter_rail_boarding/lib/uploader/s3.ex
+++ b/apps/commuter_rail_boarding/lib/uploader/s3.ex
@@ -10,6 +10,7 @@ defmodule Uploader.S3 do
   @impl true
   def upload(filename, binary) do
     full_filename = Path.join("commuter_rail_boarding", filename)
+
     request =
       S3.put_object(
         config(Uploader.S3, :bucket),

--- a/apps/commuter_rail_boarding/test/uploader/s3_test.exs
+++ b/apps/commuter_rail_boarding/test/uploader/s3_test.exs
@@ -27,7 +27,7 @@ defmodule Uploader.S3Test do
     test "uploads to a configured S3 bucket" do
       assert :ok = upload("filename", "binary")
       assert_received {:aws_request, request}
-      assert request.path == "filename"
+      assert request.path == "commuter_rail_boarding/filename"
       assert request.bucket == "test_bucket"
       assert request.body == "binary"
       assert request.headers["content-type"] == "application/json"

--- a/apps/train_loc/lib/train_loc/s3/http_client.ex
+++ b/apps/train_loc/lib/train_loc/s3/http_client.ex
@@ -7,7 +7,7 @@ defmodule TrainLoc.S3.HTTPClient do
   @impl TrainLoc.S3
   def put_object(filename, body) do
     bucket = get_bucket()
-    full_filename = Path.join("train_loc", filename)
+    full_filename = Path.join("commuter_rail_boarding/train_loc", filename)
     opts = [acl: :public_read, content_type: "application/json"]
 
     bucket


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚆Keolis Feed Transition](https://app.asana.com/0/584764604969369/1204680576534832/f)

Writes files under the `commuter_rail_boarding` prefix so as not to clobber Keolis when we cutover. Note this shouldn't be deployed (and thus probably not merged) until immediately before the cutover) as it will break Swiftly if Keolis isn't ready.