### PR TITLE
fix: write current files to correct prefix

### DIFF
--- a/apps/commuter_rail_boarding/lib/uploader/consumer.ex
+++ b/apps/commuter_rail_boarding/lib/uploader/consumer.ex
@@ -26,7 +26,7 @@ defmodule Uploader.Consumer do
     new_bucket = Application.get_env(:shared, :new_bucket)
 
     for {filename, body} <- Map.new(events) do
-      Uploader.upload(Path.join("commuter_rail_boarding", filename), body)
+      Uploader.upload(filename, body)
       Uploader.upload(filename, body, new_bucket, [])
     end
   end

--- a/apps/commuter_rail_boarding/test/uploader/consumer_test.exs
+++ b/apps/commuter_rail_boarding/test/uploader/consumer_test.exs
@@ -30,7 +30,7 @@ defmodule Uploader.ConsumerTest do
       assert Map.has_key?(objects, "console")
 
       assert Map.fetch!(objects, "console") == %{
-               "commuter_rail_boarding/a" => "third",
+               "a" => "third",
                "opts" => [acl: :public_read]
              }
     end

--- a/apps/train_loc/lib/train_loc/manager.ex
+++ b/apps/train_loc/lib/train_loc/manager.ex
@@ -160,7 +160,7 @@ defmodule TrainLoc.Manager do
   def upload_feed(feed, state) do
     with result <-
            @s3_api.put_object(
-             "commuter_rail_boarding/train_loc/VehiclePositions_enhanced.json",
+             "train_loc/VehiclePositions_enhanced.json",
              feed
            ),
          new_result <-

--- a/apps/train_loc/test/train_loc/manager_test.exs
+++ b/apps/train_loc/test/train_loc/manager_test.exs
@@ -108,7 +108,7 @@ defmodule TrainLoc.ManagerTest do
 
       assert Map.has_key?(
                objects.default,
-               "commuter_rail_boarding/train_loc/VehiclePositions_enhanced.json"
+               "train_loc/VehiclePositions_enhanced.json"
              )
     end
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚆 Keolis feed cutover](https://app.asana.com/0/584764604969369/1205399986850127/f)

Writes GTFS-RT files to the current bucket without the `commuter_rail_boarding/` prefix. Not sure why I thought they needed the prefix but they don't.