### PR TITLE
fix: ensure vehicle_id is always a string

### DIFF
--- a/apps/train_loc/lib/train_loc/encoder/vehicle_positions_enhanced.ex
+++ b/apps/train_loc/lib/train_loc/encoder/vehicle_positions_enhanced.ex
@@ -39,7 +39,7 @@ defmodule TrainLoc.Encoder.VehiclePositionsEnhanced do
         }
 
   @type entity_vehicle() :: %{
-          :id => non_neg_integer(),
+          :id => String.t(),
           optional(:assignment_status) => String.t()
         }
 
@@ -102,7 +102,7 @@ defmodule TrainLoc.Encoder.VehiclePositionsEnhanced do
   @spec entity_vehicle(Vehicle.t()) :: entity_vehicle()
   defp entity_vehicle(vehicle) do
     %{
-      id: vehicle.vehicle_id
+      id: "#{vehicle.vehicle_id}"
     }
   end
 

--- a/apps/train_loc/test/train_loc/encoder/vehicle_positions_enhanced_test.exs
+++ b/apps/train_loc/test/train_loc/encoder/vehicle_positions_enhanced_test.exs
@@ -89,7 +89,7 @@ defmodule TrainLoc.Encoder.VehiclePositionsEnhancedTest do
         assert is_binary(json_content["id"])
         assert json_trip_data["start_date"] == "20170804"
         assert json_trip_data["trip_short_name"] == vehicle.trip
-        assert json_vehicle_data["vehicle"]["id"] == vehicle.vehicle_id
+        assert json_vehicle_data["vehicle"]["id"] == Integer.to_string(vehicle.vehicle_id)
         assert json_position_data["latitude"] == vehicle.latitude
         assert json_position_data["longitude"] == vehicle.longitude
         assert json_position_data["bearing"] == vehicle.heading

--- a/apps/train_loc/test/train_loc/manager_test.exs
+++ b/apps/train_loc/test/train_loc/manager_test.exs
@@ -266,7 +266,7 @@ defmodule TrainLoc.ManagerTest do
                    },
                    "timestamp" => 1_642_722_222,
                    "trip" => %{"start_date" => "20220120"},
-                   "vehicle" => %{"id" => 1506}
+                   "vehicle" => %{"id" => "1506"}
                  }
                },
                %{
@@ -280,7 +280,7 @@ defmodule TrainLoc.ManagerTest do
                    },
                    "timestamp" => 1_642_722_222,
                    "trip" => %{"start_date" => "20220120"},
-                   "vehicle" => %{"id" => 1507}
+                   "vehicle" => %{"id" => "1507"}
                  }
                },
                %{
@@ -294,7 +294,7 @@ defmodule TrainLoc.ManagerTest do
                    },
                    "timestamp" => 1_642_722_222,
                    "trip" => %{"start_date" => "20220120", "trip_short_name" => "745"},
-                   "vehicle" => %{"id" => 1823}
+                   "vehicle" => %{"id" => "1823"}
                  }
                }
              ] ==


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [allow integer vehicle IDs](https://app.asana.com/0/584764604969369/1205504059419471/f)

This is a bug that should have been fixed a while ago; these values should be strings, not integers.
